### PR TITLE
Change Dependabot schedule to weekly and add settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,21 +4,29 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
     commit-message:
       prefix: "ci:"
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
         patterns:
-          - '*'
+          - "*"
+    open-pull-requests-limit: 20
 
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+    cooldown:
+      default-days: 7
+    allow:
+      - dependency-type: "all"
     commit-message:
       prefix: "go:"
     groups:
       dependencies:
         patterns:
-          - '*'
+          - "*"
+    open-pull-requests-limit: 20


### PR DESCRIPTION
Updated the schedule for GitHub Actions and Go modules to weekly. Added cooldown settings and allowed all dependency types for Go modules.